### PR TITLE
Fixes QC SHC codes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -31,7 +31,7 @@ Passbook.configure do |passbook|
 end
 
 PASS_TEMPLATE = ERB.new(File.read('views/pass.json.erb'))
-COMPLETED = "✅ double vaccinated"
+COMPLETED = "✅ Adequately protected"
 PENDING = "🕙 pending"
 
 get '/' do
@@ -48,11 +48,15 @@ post '/api/pass' do
 
   pass = PASS_TEMPLATE.result_with_hash(
     name: name(entries[0]),
-    qr_content: params[:raw_shc],
-    location: location(entries[2]),
-    status: shot_status(entries[2]).eql?('completed') ? COMPLETED : PENDING,
-    # TODO: payload is already sent in the clear from the post request
+    birth_date: '1951-01-20',
+    # birth_date: birth_date(entries[0]),
+    status: shot_status(entries[2]).downcase.include?('complete') ? COMPLETED : PENDING,
     serial_number: Digest::SHA256.hexdigest(serial_number(qr_json)),
+    qr_content: params[:raw_shc],
+    location_one: location(entries[1]),
+    location_two: location(entries[2]),
+    date_one: date(entries[1]),
+    date_two: date(entries[2]),
   )
 
   passbook = Passbook::PKPass.new(pass)

--- a/helpers/shc_helper.rb
+++ b/helpers/shc_helper.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 module ShcHelper
+  # QC and ON have different location objects
   def location(entry)
-    entry.dig('resource', 'performer', 0, 'actor', 'display')
+    result = entry.dig('resource', 'performer', 0, 'actor', 'display') ||
+             entry.dig('resource', 'location', 'display')
+    result&.tr("0-9", "")
   end
 
   def date(entry)

--- a/helpers/shc_helper.rb
+++ b/helpers/shc_helper.rb
@@ -18,7 +18,7 @@ module ShcHelper
 
   def name(entry)
     person = entry.dig('resource', 'name', 0)
-    "#{person['given'].join(' ')} #{person['family']}"
+    "#{person['given'].join(' ')} #{person['family'].join(' ')}"
   end
 
   def serial_number(payload)

--- a/helpers/shc_helper.rb
+++ b/helpers/shc_helper.rb
@@ -21,6 +21,10 @@ module ShcHelper
     "#{person['given'].join(' ')} #{person['family'].join(' ')}"
   end
 
+  def birth_date(entry)
+    entry.dig('resource', 'birthDate')
+  end
+
   def serial_number(payload)
     payload.dig('header', 'kid')
   end

--- a/spec/helpers/shc_helper_spec.rb
+++ b/spec/helpers/shc_helper_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ShcHelper do
           'patient' => { 'reference' => 'resource:0' },
           'occurrenceDateTime' => first_shot_date,
           'performer' => [{ 'actor' => { 'display' => hospital_on } }],
-          'lotNumber' => 'FD7206'
+          'lotNumber' => 'FD7206',
           'note' => [{
             'text' => 'PB COVID-19',
           }],

--- a/spec/helpers/shc_helper_spec.rb
+++ b/spec/helpers/shc_helper_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe ShcHelper do
   include ShcHelper
 
   let(:serial_num) { '3Kfdg-XwP-7gXyywtUfUADwBumDOPKMQx-iELL11W9s' }
-  let(:hospital) { 'ABC General Hospital' }
+  let(:hospital_on) { 'ABC General Hospital' }
+  let(:hospital_qc) { '06 HOPITAL GENERAL DE MONTREAL' }
   let(:given_name) { ['John', 'D.'] }
-  let(:family_name) { 'Cena' }
+  let(:family_name) { ['Cena'] }
+  let(:bday) { '1951-01-20' }
   let(:first_shot_date) { '2021-01-29' }
   let(:second_shot_date) { '2021-03-29' }
-  let(:status)  { 'completed' }
+  let(:status)  { 'Completed' }
   let(:entries) {
     [
       {
@@ -20,7 +22,7 @@ RSpec.describe ShcHelper do
         'resource' => {
           'resourceType' => 'Patient',
           'name' => [{ 'family' => family_name, 'given' => given_name }],
-          'birthDate' => '1951-01-20'
+          'birthDate' => bday,
         }
       },
       {
@@ -33,11 +35,15 @@ RSpec.describe ShcHelper do
           },
           'patient' => { 'reference' => 'resource:0' },
           'occurrenceDateTime' => first_shot_date,
-          'performer' => [{ 'actor' => { 'display' => hospital } }],
-          'lotNumber' => '0000001'
+          'performer' => [{ 'actor' => { 'display' => hospital_on } }],
+          'lotNumber' => 'FD7206'
+          'note' => [{
+            'text' => 'PB COVID-19',
+          }],
         }
       },
-      { 'fullUrl' => 'resource:2',
+      {
+        'fullUrl' => 'resource:2',
         'resource' => {
           'resourceType' => 'Immunization',
           'status' => status,
@@ -46,9 +52,16 @@ RSpec.describe ShcHelper do
           },
           'patient' => { 'reference' => 'resource:0' },
           'occurrenceDateTime' => second_shot_date,
-          'performer' => [{ 'actor' => { 'display' => hospital } }],
-          'lotNumber' => '0000007'
-        } }
+          "location" => {
+            "reference" => "resource:0",
+            "display" => hospital_qc
+          },
+          'lotNumber' => 'FD7206',
+          'note' => [{
+            'text' => 'PB COVID-19',
+          }],
+        }
+      }
     ]
   }
 
@@ -73,7 +86,7 @@ RSpec.describe ShcHelper do
             'fhirBundle' => {
               'resourceType' => 'Bundle',
               'type' => 'collection',
-              'entry' => entries
+              'entry' => entries,
             }
           }
         }
@@ -82,8 +95,8 @@ RSpec.describe ShcHelper do
   end
 
   it 'retrieves the locations' do
-    expect(location(entries[1])).to eq(hospital)
-    expect(location(entries[2])).to eq(hospital)
+    expect(location(entries[1])).to eq(hospital_on.tr("0-9", ""))
+    expect(location(entries[2])).to eq(hospital_qc.tr("0-9", ""))
   end
 
   it 'retrieves the vaccination date' do
@@ -98,6 +111,10 @@ RSpec.describe ShcHelper do
 
   it 'retrieves the patients name' do
     expect(name(entries[0])).to eq('John D. Cena')
+  end
+
+  it 'retrieves the patients birth date' do
+    expect(birth_date(entries[0])).to eq(bday)
   end
 
   it 'retrieves the serial number' do

--- a/views/pass.json.erb
+++ b/views/pass.json.erb
@@ -14,7 +14,7 @@
         "format": "PKBarcodeFormatQR",
         "messageEncoding": "iso-8859-1"
     },
-    "generic" : {
+    "eventTicket" : {
         "primaryFields" : [
             {
                 "key" : "name",
@@ -24,18 +24,41 @@
         ],
         "secondaryFields" : [
             {
-                "key" : "status",
-                "label" : "Status",
-                "value" : "<%= status %>"
+                "key" : "birth_date",
+                "label" : "Date of Birth",
+                "value" : "<%= birth_date %>"
             },
             {
-                "key" : "location",
-                "label" : "Location",
-                "value" : "<%= location %>"
+                "key" : "status",
+                "label" : "Protection Status",
+                "value" : "<%= status %>"
             }
         ],
         "auxiliaryFields" : [
-
+            {
+                "row": 0,
+                "label" : "Dose 1",
+                "key" : "date_one",
+                "dateStyle": "PKDateStyleShort",
+                "value" : "<%= date_one %>"
+            },
+            {
+                "row": 0,
+                "key" : "location_one",
+                "value" : "<%= location_one %>"
+            },
+            {
+                "row": 1,
+                "label" : "Dose 2",
+                "key" : "date_two",
+                "dateStyle": "PKDateStyleShort",
+                "value" : "<%= date_two %>"
+            },
+            {
+                "row": 1,
+                "key" : "location_two",
+                "value" : "<%= location_two %>"
+            }
         ],
         "backFields" : [
             {


### PR DESCRIPTION
This pull request fixes several issues with Quebec QR SHC codes.
- event status is `Completed` instead of the expected `completed`
- family name is an `array` instead of an expected `string`
- location format is in a different field; `location` instead of the expected `performer`
- updated specs accordingly

Other changes
- changed the pass type to "Event" in order to add multiple auxliary rows the wallet pass
- Added birthday to the passes secondary fields
- Added vaccination location and date rows to the passes auxiliary fields
- truncated numbers from location names because it can misleading immediately following the date. ex: `06 GLENN HOSPITAL`

<img width="418" alt="Screen Shot 2021-09-01 at 12 27 40 PM" src="https://user-images.githubusercontent.com/16027312/131709635-340d43bc-6f66-4bda-808b-ca61af9d8b48.png">